### PR TITLE
disconnect AudioBufferSourceNode and close AudioContext

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function handleWebAudioEnded () {
   source.disconnect(context.destination)
   source = null
   context.close()
+  context = null
   maybeCleanup()
 }
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function handleMousedown () {
   if (!isWebAudioEnabled) {
     context = new AudioContext()
     source = context.createBufferSource()
-    source.buffer = context.createBuffer(1, 1, 22050) // .1 sec of silence
+    source.buffer = context.createBuffer(1, 1, 22050) // .045 msec of silence
     source.connect(context.destination)
     source.addEventListener('ended', handleWebAudioEnded)
     source.start()

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ let isHtmlAudioEnabled = false
 let isWebAudioEnabled = false
 
 let audio
+let context
 let source
 
 function init () {
@@ -28,7 +29,7 @@ function handleMousedown () {
     audio.play().catch(() => {})
   }
   if (!isWebAudioEnabled) {
-    const context = new AudioContext()
+    context = new AudioContext()
     source = context.createBufferSource()
     source.buffer = context.createBuffer(1, 1, 22050) // .1 sec of silence
     source.connect(context.destination)
@@ -49,7 +50,9 @@ function handleWebAudioEnded () {
   if (isWebAudioEnabled) return
   isWebAudioEnabled = true
   source.removeEventListener('ended', handleWebAudioEnded)
+  source.disconnect(context.destination)
   source = null
+  context.close()
   maybeCleanup()
 }
 


### PR DESCRIPTION
Hi @feross,

thanks for providing this library. It is really useful.

I added three lines of code to which do also disconnect the AudioBufferSourceNode and close the AudioContext when the ended event of the AudioBufferSourceNode fires just to make sure that everything can be collected by the browser.

I made a quick test on a recent iPad and it still works.

I also corrected the comment which describes the duration of the AudioBuffer. I hope that's okay.

Please let me know if I need to change anything.