### PR TITLE
add TypeScript type definitons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function init (): void;
+
+export default init;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/unmute-ios-audio.git"


### PR DESCRIPTION
This pull request adds a basic type definitions file to ease the usage with TypeScript.

It is meant to fix #2.

I tried to do it in similar way as the type definitions of [safe-buffer](https://github.com/feross/safe-buffer). I only did not wrap the types in a module definition as this is not recommended anymore as far as I know.