### PR TITLE
feat: create custom data URI

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@
 
 module.exports = init
 
-const AudioContext = window.AudioContext || window.webkitAudioContext
-
 let isHtmlAudioEnabled = false
 let isWebAudioEnabled = false
 
@@ -28,13 +26,16 @@ function createSilentAudioFile (context) {
 }
 
 function init () {
-  context = new AudioContext()
-  audio = document.createElement('audio')
-  audio.preload = 'auto'
-  audio.src = createSilentAudioFile(context)
-  audio.addEventListener('ended', handleAudioEnded)
+  if (window.webkitAudioContext) {
+    context = new window.webkitAudioContext() // eslint-disable-line new-cap
 
-  window.addEventListener('mousedown', handleMousedown)
+    audio = document.createElement('audio')
+    audio.preload = 'auto'
+    audio.src = createSilentAudioFile(context)
+    audio.addEventListener('ended', handleAudioEnded)
+
+    window.addEventListener('mousedown', handleMousedown)
+  }
 }
 
 function handleMousedown () {

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ module.exports = init
 
 const AudioContext = window.AudioContext || window.webkitAudioContext
 
-const silentAudioFile = 'data:audio/mp3;base64,//MkxAAHiAICWABElBeKPL/RANb2w+yiT1g/gTok//lP/W/l3h8QO/OCdCqCW2Cw//MkxAQHkAIWUAhEmAQXWUOFW2dxPu//9mr60ElY5sseQ+xxesmHKtZr7bsqqX2L//MkxAgFwAYiQAhEAC2hq22d3///9FTV6tA36JdgBJoOGgc+7qvqej5Zu7/7uI9l//MkxBQHAAYi8AhEAO193vt9KGOq+6qcT7hhfN5FTInmwk8RkqKImTM55pRQHQSq//MkxBsGkgoIAABHhTACIJLf99nVI///yuW1uBqWfEu7CgNPWGpUadBmZ////4sL//MkxCMHMAH9iABEmAsKioqKigsLCwtVTEFNRTMuOTkuNVVVVVVVVVVVVVVVVVVV//MkxCkECAUYCAAAAFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV'
-
 let isHtmlAudioEnabled = false
 let isWebAudioEnabled = false
 
@@ -15,10 +13,25 @@ let audio
 let context
 let source
 
+// This will return a seven samples long 8 bit mono WAVE file.
+function createSilentAudioFile (context) {
+  const arrayBuffer = new ArrayBuffer(10)
+  const dataView = new DataView(arrayBuffer)
+
+  dataView.setUint32(0, context.sampleRate, true)
+  dataView.setUint32(4, context.sampleRate, true)
+  dataView.setUint16(8, 1, true)
+
+  const missingCharacters = window.btoa(String.fromCharCode(...new Uint8Array(arrayBuffer))).slice(0, 13)
+
+  return `data:audio/wav;base64,UklGRisAAABXQVZFZm10IBAAAAABAAEA${missingCharacters}AgAZGF0YQcAAACAgICAgICAAAA=`
+}
+
 function init () {
+  context = new AudioContext()
   audio = document.createElement('audio')
   audio.preload = 'auto'
-  audio.src = silentAudioFile
+  audio.src = createSilentAudioFile(context)
   audio.addEventListener('ended', handleAudioEnded)
 
   window.addEventListener('mousedown', handleMousedown)
@@ -29,7 +42,6 @@ function handleMousedown () {
     audio.play().catch(() => {})
   }
   if (!isWebAudioEnabled) {
-    context = new AudioContext()
     source = context.createBufferSource()
     source.buffer = context.createBuffer(1, 1, 22050) // .045 msec of silence
     source.connect(context.destination)


### PR DESCRIPTION
Hi Feross,

I noticed that this module does sometimes trigger a very strange bug in Safari on iOS which causes an AudioContext to run at a non native sampleRate. The `silentAudioFile` is an MP3 encoded at 24kHz and sometimes this causes Safari to assign that value to the sampleRate of an AudioContext. This does of course not work and causes all sorts of bugs.

For more info about that bug please check out this issue that a user filed on a Web Audio polyfill that I maintain: chrisguttandin/standardized-audio-context#489

The bug can be circumvented by only using media files with the same sampleRate that the device has. Therefore I turned the `silentAudioFile` constant into a function which creates a data URI with the native sampleRate of the device. I experimented a bit and creating a wave file with only 7 samples and one channel was the smallest file that did work for me.

Unfortunately that means that the AudioContext needs to be created inside the `init()` function again which means my changes would revert the changes you made here: https://github.com/feross/unmute-ios-audio/commit/fd8440f9bb65c8c8665883d3a2883f562e5d8999.

Should we maybe only execute the init function if the webkitAudioContext is available. That would prevent this package from running in Chrome at all. Or is this workaround also necessary for Chrome on iOS?