### PR TITLE
reintroduce types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export = unmuteIosAudio;
+declare function unmuteIosAudio(): void;

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
       "type": "consulting",
       "url": "https://feross.org/support"
     }
-  ]
+  ],
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Hi Feross, this pull request is meant to bring back the type definition file. Since v3.7 of TypeScript it is possible to generate a `.d.ts` file from source code written in JavaScript. This is what I did. The `index.d.ts` file can be generated by running `tsc`.

I know that you deliberately removed the previous type definition file. However I think that the situation is different now as we can generate it and that way be sure it keeps up to date.

Feel free to reject this pull request if you want to keep this repo free of `.d.ts` files.