### PR TITLE
Use context sample-rate in webaudio silence buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function unmuteIosAudio () {
     context = new AudioContext()
 
     source = context.createBufferSource()
-    source.buffer = context.createBuffer(1, 1, 22050) // .045 msec of silence
+    source.buffer = context.createBuffer(1, 1, sampleRate) // 1 / sampleRate seconds duration
     source.connect(context.destination)
     source.start()
 


### PR DESCRIPTION
Seems obvious? Why enforce potential resample, as most common destinations run on 44khz?